### PR TITLE
Allow to load plugin in headless environment

### DIFF
--- a/src/org/openstreetmap/josm/plugins/missinggeo/MissingGeometryPlugin.java
+++ b/src/org/openstreetmap/josm/plugins/missinggeo/MissingGeometryPlugin.java
@@ -15,6 +15,7 @@
  */
 package org.openstreetmap.josm.plugins.missinggeo;
 
+import java.awt.GraphicsEnvironment;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
@@ -217,9 +218,11 @@ implements CommentObserver, LayerChangeListener, MouseListener, PreferenceChange
     @Override
     public void mapFrameInitialized(final MapFrame oldMapFrame, final MapFrame newMapFrame) {
         if (Main.map != null) {
-            dialog = new MissingGeometryDetailsDialog();
-            newMapFrame.addToggleDialog(dialog);
-            dialog.getButton().addActionListener(new ToggleButtonActionListener());
+            if (!GraphicsEnvironment.isHeadless()) {
+                dialog = new MissingGeometryDetailsDialog();
+                newMapFrame.addToggleDialog(dialog);
+                dialog.getButton().addActionListener(new ToggleButtonActionListener());
+            }
             registerListeners();
             addLayer();
         }
@@ -310,9 +313,13 @@ implements CommentObserver, LayerChangeListener, MouseListener, PreferenceChange
     private void registerListeners() {
         NavigatableComponent.addZoomChangeListener(this);
         MapView.addLayerChangeListener(this);
-        Main.map.mapView.addMouseListener(this);
+        if (Main.isDisplayingMapView()) {
+            Main.map.mapView.addMouseListener(this);
+        }
         Main.pref.addPreferenceChangeListener(this);
-        dialog.registerCommentObserver(this);
+        if (dialog != null) {
+            dialog.registerCommentObserver(this);
+        }
     }
 
     private void retrieveComment(final Tile tile) {


### PR DESCRIPTION
We load all plugins in headless environment in JOSM unit tests. See https://josm.openstreetmap.de/jenkins/job/JOSM/jdk=JDK7/lastUnstableBuild/testReport/org.openstreetmap.josm.plugins/PluginHandlerTest/testValidityOfAvailablePlugins/ where we get:

```
ERROR: org.openstreetmap.josm.plugins.PluginException: An error occurred in plugin missingRoads. Cause: java.lang.reflect.InvocationTargetException. Cause: java.lang.ExceptionInInitializerError. Cause: java.lang.NullPointerException
org.openstreetmap.josm.plugins.PluginException: An error occurred in plugin missingRoads
	at org.openstreetmap.josm.plugins.PluginProxy.handlePluginException(PluginProxy.java:38)
	at org.openstreetmap.josm.plugins.PluginProxy.mapFrameInitialized(PluginProxy.java:48)
	at org.openstreetmap.josm.Main.addMapFrameListener(Main.java:1613)
	at org.openstreetmap.josm.plugins.PluginHandler.loadPlugin(PluginHandler.java:710)
	at org.openstreetmap.josm.plugins.PluginHandler.loadPlugins(PluginHandler.java:770)
	at org.openstreetmap.josm.plugins.PluginHandler.loadLatePlugins(PluginHandler.java:809)
	at org.openstreetmap.josm.plugins.PluginHandlerTest.testValidityOfAvailablePlugins(PluginHandlerTest.java:70)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at junit.framework.JUnit4TestAdapter.run(JUnit4TestAdapter.java:38)
	at org.apache.tools.ant.taskdefs.optional.junit.JUnitTestRunner.run(JUnitTestRunner.java:535)
	at org.apache.tools.ant.taskdefs.optional.junit.JUnitTestRunner.launch(JUnitTestRunner.java:1182)
	at org.apache.tools.ant.taskdefs.optional.junit.JUnitTestRunner.main(JUnitTestRunner.java:1004)
Caused by: java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.openstreetmap.josm.plugins.PluginProxy.mapFrameInitialized(PluginProxy.java:44)
	... 27 more
Caused by: java.lang.ExceptionInInitializerError
	at org.openstreetmap.josm.plugins.missinggeo.gui.details.MissingGeometryDetailsDialog.<init>(Unknown Source)
	at org.openstreetmap.josm.plugins.missinggeo.MissingGeometryPlugin.mapFrameInitialized(Unknown Source)
	... 32 more
Caused by: java.lang.NullPointerException
	at org.openstreetmap.josm.plugins.missinggeo.gui.GuiBuilder.<clinit>(Unknown Source)
	... 34 more
```