### PR TITLE
fix NPE in headless environment

### DIFF
--- a/src/org/openstreetmap/josm/plugins/missinggeo/MissingGeometryPlugin.java
+++ b/src/org/openstreetmap/josm/plugins/missinggeo/MissingGeometryPlugin.java
@@ -88,7 +88,7 @@ implements CommentObserver, LayerChangeListener, MouseListener, PreferenceChange
 
         private void updateSelection(final DataSet result) {
             final Tile tile = layer.lastSelectedTile();
-            if (result != null) {
+            if (result != null && !GraphicsEnvironment.isHeadless()) {
                 if (!result.getClusters().isEmpty()) {
                     dialog.updateData(null, null);
                 } else if (tile != null) {


### PR DESCRIPTION
Seen in JOSM unit test:
    java.lang.NullPointerException
	at org.openstreetmap.josm.plugins.missinggeo.MissingGeometryPlugin$DataUpdateThread.updateSelection(Unknown Source)
	at org.openstreetmap.josm.plugins.missinggeo.MissingGeometryPlugin$DataUpdateThread.access$100(Unknown Source)
	at org.openstreetmap.josm.plugins.missinggeo.MissingGeometryPlugin$DataUpdateThread$1.run(Unknown Source)